### PR TITLE
Blender 5.0 Compatibility Fix, Also added a gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 
 schema_version = "1.0.3"
 id = "render_manager"
-version = "2.0.0"
+version = "3.0.0"
 name = "Render Manager"
 tagline = "Manage render visibility, passes, and node-based file outputs"
 maintainer = "BlenderBob & TinkerBoi <support@tinkerboi.com>"


### PR DESCRIPTION
I Added a Patch for Blender 5.0 Compatibility for the 

"Create Render Nodes" Button

I want to Clarify here Im not 100% sure if what it does is correct, but at least it looks correct to me

Please Test this patch before Accepting the Changes, as I dont know if this is correct or not

PLEASE CHECK AND TEST IF IT WORKS WELL IF YOU WANT TO TAKE THIS PATCH

I have to do alot of assumption work here so it might not be all correct

I also might miss a thing or two so please do check that as well

You can Download from my Fork and Test if it is working properly
https://github.com/BlenderBoi/Render-Manager

Only then you accept the pull request

Technical Node:
All The Passes name are changed, so theres alot of changes in there
For example

"DiffDir" -> "Diffuse Direct"

Many of the hardcoded name in the script, 
I replaced all the hardcoded name to use the function get_pass_name(pass_name)

this way In future if the pass name changes in the new version of blender, i can just modify get_pass_name instead of all the hardcoded value

-------------

CompositorNodeMixRGB is removed, and replaced with ShaderNodeMix

-------------

Output Node no longer have layer_slots and is replaced with file_output_items

-------------

for whatever reason, to get the last input in a node, i need to use inputs[-2] instead of inputs[-1]

------------

Many function I added as a wrapper to have a if condition to work in 5.0 or 5.0 and below

------------

There might be other thing i missed out in the note, since this is a big change

I might have a careless mistake here and there from replacing all the hardcoded value in the code
